### PR TITLE
fix: COCOA_LDN exchange now ICE/EU/Com

### DIFF
--- a/bcutils/config.py
+++ b/bcutils/config.py
@@ -27,7 +27,7 @@ CONTRACT_MAP = {
     "CHFJPY": {"code": "UP", "cycle": "HMUZ", "exchange": "CME"},
     "CLP": {"code": "N5", "cycle": "FGHJKMNQUVXZ", "exchange": "CME"},
     "CNH-onshore": {"code": "ZP", "cycle": "FGHJKMNQUVXZ", "exchange": "ICE/SG"},
-    "COCOA_LDN": {"code": "CA", "cycle": "HKNUZ", "exchange": "ICE/EU"},
+    "COCOA_LDN": {"code": "CA", "cycle": "HKNUZ", "exchange": "ICE/EU/Com"},
     "COCOA_NY": {"code": "CC", "cycle": "HKNUZ", "exchange": "ICE/US"},
     "COFFEE": {"code": "KC", "cycle": "HKNUZ", "exchange": "ICE/US"},
     "COPPER": {"code": "HG", "cycle": "FHJMNUVZ", "exchange": "COMEX"},


### PR DESCRIPTION
Hi,

Thanks for publishing this utility.
However, when I came to use it, I got a unknown exchange error for the `COCOA_LDN` contract.
It turns out it was just missing the `/Com` suffix in the config.

So here's the fix.
See change in config.py.